### PR TITLE
Makefile: force symlink creation to allow multiple installs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-
 luamod_prefix=/usr/share/lua
 
 default:
@@ -12,16 +11,16 @@ install:
 	@install -m 644 lua/*.lua ${DESTDIR}/${luamod_prefix}/5.1/
 
 	@install -d -m 755 ${DESTDIR}/${luamod_prefix}/5.2/
-	@ln -sr ${DESTDIR}/${luamod_prefix}/5.1/strict.lua ${DESTDIR}/${luamod_prefix}/5.2/
-	@ln -sr ${DESTDIR}/${luamod_prefix}/5.1/ansicolors.lua ${DESTDIR}/${luamod_prefix}/5.2/
-	@ln -sr ${DESTDIR}/${luamod_prefix}/5.1/utils.lua ${DESTDIR}/${luamod_prefix}/5.2/
-	@ln -sr ${DESTDIR}/${luamod_prefix}/5.1/time.lua ${DESTDIR}/${luamod_prefix}/5.2/
+	@ln -srf ${DESTDIR}/${luamod_prefix}/5.1/strict.lua ${DESTDIR}/${luamod_prefix}/5.2/
+	@ln -srf ${DESTDIR}/${luamod_prefix}/5.1/ansicolors.lua ${DESTDIR}/${luamod_prefix}/5.2/
+	@ln -srf ${DESTDIR}/${luamod_prefix}/5.1/utils.lua ${DESTDIR}/${luamod_prefix}/5.2/
+	@ln -srf ${DESTDIR}/${luamod_prefix}/5.1/time.lua ${DESTDIR}/${luamod_prefix}/5.2/
 
 	@install -d -m 755 ${DESTDIR}/${luamod_prefix}/5.3/
-	@ln -sr ${DESTDIR}/${luamod_prefix}/5.1/strict.lua ${DESTDIR}/${luamod_prefix}/5.3/
-	@ln -sr ${DESTDIR}/${luamod_prefix}/5.1/ansicolors.lua ${DESTDIR}/${luamod_prefix}/5.3/
-	@ln -sr ${DESTDIR}/${luamod_prefix}/5.1/utils.lua ${DESTDIR}/${luamod_prefix}/5.3/
-	@ln -sr ${DESTDIR}/${luamod_prefix}/5.1/time.lua ${DESTDIR}/${luamod_prefix}/5.3/
+	@ln -srf ${DESTDIR}/${luamod_prefix}/5.1/strict.lua ${DESTDIR}/${luamod_prefix}/5.3/
+	@ln -srf ${DESTDIR}/${luamod_prefix}/5.1/ansicolors.lua ${DESTDIR}/${luamod_prefix}/5.3/
+	@ln -srf ${DESTDIR}/${luamod_prefix}/5.1/utils.lua ${DESTDIR}/${luamod_prefix}/5.3/
+	@ln -srf ${DESTDIR}/${luamod_prefix}/5.1/time.lua ${DESTDIR}/${luamod_prefix}/5.3/
 
 
 uninstall:


### PR DESCRIPTION
We install this project in a Jenkins job which currently fails succeeds in the first run but fails in subsequent runs because `ln` fails when the specified symlink already exists.